### PR TITLE
Failed test on line 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:2.7-alpine
+
+LABEL maintainer='SUDARSAN BHARGAVAN'
+
+WORKDIR /BlackBoxTests
+COPY ./networkxtest.py /BlackBoxTests/networkxtest.py
+RUN apk add py-setuptools py-pip
+RUN python2 -m pip install networkx pytest
+
+ENV TERM xterm
+
+CMD ["python", "/BlackBoxTests/networkxtest.py"]

--- a/networkxtest.py
+++ b/networkxtest.py
@@ -15,9 +15,11 @@ class NodesTest(unittest.TestCase):
     def test_integer_nodes(self):
         '''Should return the copy of the Graph's nodes in a list - Integer'''
         graph = nx.Graph([(1,2),(1,4),(1,5),(2,3),(3,4),(3,5),(5,6),(6,7)])
+        #nodeList = list(nx.nodes(graph))
         nodeList = list(nx.nodes(graph))
         result = [1,2,3,4,5,6,7]
-        self.assertListEqual(nodeList, result)
+        #self.assertListEqual(nodeList, result)
+        self.assertEqual(set(nodeList),set(result))
         
         graph = nx.Graph([(-1,-2),(-1,-4),(-1,-5),(-2,-3),(-3,-4),(-3,-5),(-5,-6),(-6,-7)])
         nodeList = sorted(list(nx.nodes(graph)))


### PR DESCRIPTION
self.assertListEqual(nodeList, result)
this previously failed, because two lists contained same elements, but in different order
AssertionError: Lists differ: [1, 2, 4, 5, 3, 6, 7] != [1, 2, 3, 4, 5, 6, 7]
Sean, can you take a look and accept a pull request if it fixes the test the way it should?